### PR TITLE
Delete unused const

### DIFF
--- a/application/modules/sidebox_countdown/controllers/Countdown.php
+++ b/application/modules/sidebox_countdown/controllers/Countdown.php
@@ -7,7 +7,7 @@ use MX\MX_Controller;
  */
 class Countdown extends MX_Controller
 {
-    const string DS = DIRECTORY_SEPARATOR;
+    /*const string DS = DIRECTORY_SEPARATOR;*/
 
     private static string $moduleUrl;
     private static string $moduleName;

--- a/application/modules/sidebox_countdown/controllers/Countdown.php
+++ b/application/modules/sidebox_countdown/controllers/Countdown.php
@@ -7,8 +7,6 @@ use MX\MX_Controller;
  */
 class Countdown extends MX_Controller
 {
-    /*const string DS = DIRECTORY_SEPARATOR;*/
-
     private static string $moduleUrl;
     private static string $moduleName;
 


### PR DESCRIPTION
Line 10 of the controller is not currently used, however when activating it, it generates an error on the site.

`ParseError: syntax error, unexpected identifier "DS", expecting "=" 
[Method: get
in APPPATH/modules/sidebox_countdown/controllers/Countdown.php on line 10.
 1 APPPATH/libraries/Template.php(272): Template->loadSideboxes('top')`

This was mentioned so that the module could be used without problems.

` /* const string DS = DIRECTORY_SEPARATOR;*/`