### PR TITLE
Fix sidebox spotlight

### DIFF
--- a/application/modules/sidebox_spotlight/assets/js/admin.js
+++ b/application/modules/sidebox_spotlight/assets/js/admin.js
@@ -9,10 +9,10 @@ var Spotlight = {
 	 * Links for the ajax requests
 	 */
 	Links: {
-		remove: "sidebox_Spotlight/admin/delete/",
-		create: "sidebox_Spotlight/admin/create/",
-		move: "sidebox_Spotlight/admin/move/",
-		save: "sidebox_Spotlight/admin/save/",
+		remove: "sidebox_spotlight/admin/delete/",
+		create: "sidebox_spotlight/admin/create/",
+		move: "sidebox_spotlight/admin/move/",
+		save: "sidebox_spotlight/admin/save/",
 	},
 
 	/**
@@ -42,7 +42,7 @@ var Spotlight = {
 
 				$.get(Config.URL + removeLink + id, function (data) {
 					console.log(data);
-					window.location = Config.URL + "sidebox_Spotlight/admin";
+					window.location = Config.URL + "sidebox_spotlight/admin";
 
 				});
 			}
@@ -66,7 +66,7 @@ var Spotlight = {
 
 		$.post(Config.URL + this.Links.create, values, function (data) {
 			if (data == "yes") {
-				window.location = Config.URL + "sidebox_Spotlight/admin";
+				window.location = Config.URL + "sidebox_spotlight/admin";
 			} else {
 				console.log(data);
 				Swal.fire({
@@ -127,7 +127,7 @@ var Spotlight = {
 
 		$.post(Config.URL + this.Links.save + id, values, function (data) {
 			if (data == "yes") {
-				window.location = Config.URL + "sidebox_Spotlight/admin";
+				window.location = Config.URL + "sidebox_spotlight/admin";
 			} else {
 				console.log(data);
 				Swal.fire({

--- a/application/modules/sidebox_spotlight/controllers/Admin.php
+++ b/application/modules/sidebox_spotlight/controllers/Admin.php
@@ -37,7 +37,7 @@ class Admin extends MX_Controller
         $content = $this->administrator->box('spotlight', $output);
 
         // Output my content. The method accepts the same arguments as template->view
-        $this->administrator->view($content, false, "modules/sidebox_Spotlight/assets/js/admin.js");
+        $this->administrator->view($content, false, "modules/sidebox_spotlight/assets/js/admin.js");
     }
 
     public function create()
@@ -108,7 +108,7 @@ class Admin extends MX_Controller
         $content = $this->administrator->box('spotlight', $output);
 
         // Output my content. The method accepts the same arguments as template->view
-        $this->administrator->view($content, false, "modules/sidebox_Spotlight/assets/js/admin.js");
+        $this->administrator->view($content, false, "modules/sidebox_spotlight/assets/js/admin.js");
     }
 
     public function save($id = false)


### PR DESCRIPTION
Sidebox Spotlight (Admin side)
does not work on Unix systems due to case sensitivity issues.
Adjusted the route inside .js and controllers files to avoid this problem.
(The bug does not affect Windows systems)