### PR TITLE
[update] app/modules/admin $timestamp must be type int, string given

### DIFF
--- a/application/modules/admin/controllers/Sessions.php
+++ b/application/modules/admin/controllers/Sessions.php
@@ -41,7 +41,7 @@ class Sessions extends MX_Controller
                 }
 
                 $date = new DateTime();
-                $date->setTimestamp($value["timestamp"]);
+                $date->setTimestamp((int)$value["timestamp"]);
 
                 $user_agent->parse($value['user_agent'] ?? '');
 


### PR DESCRIPTION
I had the issue as i visit the Users-> Active sessions page it was showing this error below.

![image](https://github.com/user-attachments/assets/3baaec82-1eef-4abf-b737-d8db7beeae7f)
