### PR TITLE
[update] app/modules/admin 12h: to 24H:

### DIFF
--- a/application/modules/admin/controllers/Admin.php
+++ b/application/modules/admin/controllers/Admin.php
@@ -352,8 +352,8 @@ class Admin extends MX_Controller
         $query = $this->connection->table('uptime')->where('realmid', $realm_id)->get();
         $last = $query->getLastRow('array');
         if (isset($last)) {
-            $first_date = new DateTime(date('Y-m-d h:i:s', $last['starttime']));
-            $second_date = new DateTime(date('Y-m-d h:i:s'));
+            $first_date = new DateTime(date('Y-m-d H:i:s', $last['starttime']));
+            $second_date = new DateTime(date('Y-m-d H:i:s'));
 
             $difference = $first_date->diff($second_date);
 


### PR DESCRIPTION
I had the problem when the time was over 12:00, or at another specific time because my server automatically restarts at 04:00, then the counter for the uptime in the realm boxes was counting backward and was wrong at this point. It caused by the 12 h: - it should be 24 H: so the emulators run also on 24 hours clock.