### PR TITLE
Add missing language keys for edit_group view

### DIFF
--- a/application/modules/admin/language/english/admin.php
+++ b/application/modules/admin/language/english/admin.php
@@ -407,4 +407,8 @@ $lang = [
     'auth_settings_help' => 'Settings related to Realmd/Logon/Auth database and account password encryption.',
     'add_new_realm' => 'Add a new realm',
     'host' => 'Host',
+    'edit_group'  => 'Edit group',
+    'color'       => 'Color',
+    'no_accounts' => 'No accounts found',
+    'permissions' => 'Permissions',
 ];


### PR DESCRIPTION
The following keys were missing from the admin language file, causing a 'Language string not found' error when loading the edit group page:
- edit_group
- color
- no_accounts
- permissions